### PR TITLE
Allow `github <path>`

### DIFF
--- a/github/github
+++ b/github/github
@@ -11,25 +11,35 @@ if __name__ == '__main__':
     sys.path.append(root_dir)
 
 from util import github
+from util.root import git_root
 
 
 PAGES = ['', 'issues', 'pulls', 'commits', 'wiki', 'pulse', 'graphs']
 
 
 def usage():
-    sys.stderr.write('''Usage: %s [page]
+    sys.stderr.write('''Usage: %s [page]|<path>
 
 Where page is one of {%s}. If page is not specified, opens the repo root.
+If you pass in a path, it will open that file in the GitHub code browser.
 ''' % (sys.argv[0], ', '.join(PAGES[1:])))
     sys.exit(1)
 
 
+def relative_to_root(path):
+    """Takes any path and returns one relative to the git root.
+
+    This is important when running `github <path>` from a subdirectory.
+    """
+    abspath = os.path.abspath(path)
+    absroot = os.path.abspath(git_root())
+    p = os.path.relpath(abspath, absroot)
+    assert '..' not in p, '%s not under\n%s' % (abspath, absroot)
+    return p
+
+
 if __name__ == '__main__':
     if len(sys.argv) > 2:
-        usage()
-
-    page = sys.argv[1] if len(sys.argv) > 1 else ''
-    if page not in PAGES:
         usage()
 
     remotes = github.get_github_remotes()
@@ -43,5 +53,15 @@ if __name__ == '__main__':
         chosen_remote = remotes[0].path
         sys.stderr.write('Found multiple remotes. Using %s\n' % chosen_remote)
 
-    webbrowser.open_new_tab(github.make_github_url(remote) + '/' + page)
+    repo_url = github.make_github_url(remote)
+
+    arg = sys.argv[1] if len(sys.argv) > 1 else ''
+    if arg in PAGES:
+        url = '%s/%s' % (repo_url, arg)
+    elif os.path.exists(arg):
+        url = '%s/blob/master/%s' % (repo_url, relative_to_root(arg))
+    else:
+        usage()
+
+    webbrowser.open_new_tab(url)
     sys.exit(0)


### PR DESCRIPTION
Fixes #59 

I punted on referencing the current tree—if you have ideas on how to make sure the current tree exists on GitHub, I'm all ears.