### PR TITLE
Add g rim alias

### DIFF
--- a/rebase/.gitconfig
+++ b/rebase/.gitconfig
@@ -5,6 +5,7 @@
         rc      = rebase --continue
         rem     = rebase master
         ri      = rebase -i
+        rim     = rebase -i master
         rs      = rebase --skip
 	arc = add-rebase-continue.sh
 	aurc = add-u-rebase-continue


### PR DESCRIPTION
For `git rebase --interactive master`. When I run `rebase --interactive`, this is pretty much always how I do it.