### PR TITLE
Add a --remote option to git-delete-merged-branches

### DIFF
--- a/branch/.git-rc
+++ b/branch/.git-rc
@@ -9,3 +9,4 @@ alias gbu="g bu"
 alias gbr="g br"
 
 alias gcb="g cb"
+alias gdmbr="g dmbr"

--- a/branch/.gitconfig
+++ b/branch/.gitconfig
@@ -1,11 +1,12 @@
 [alias]
-        bm      = branch -m
+        bm = branch -m
 	b = branches
 	bmv = branch-move
 	br = remote-branches
 	bu = branch-upstream
 	cb = current-branch
 	dmb = delete-merged-branches
+	dmbr = delete-merged-branches --remote
 	lb = local-branches
 	nb = new-branch
 	ub = update-branch

--- a/branch/git-delete-merged-branches
+++ b/branch/git-delete-merged-branches
@@ -1,5 +1,16 @@
 #!/bin/bash
 
-# Delete branches which have been merged into the current one.
+# Delete local branches which have been merged into the current one.
+# If you pass --remote, it will prune merged branches instead.
 
-git branch --merged origin/HEAD | grep -v '^*' | xargs git branch -d
+if [[ $* == *--remote* ]]; then
+  # See http://stackoverflow.com/a/8236216/388951
+  git branch -a --merged remotes/origin/master \
+    | grep -v master \
+    | grep "remotes/origin/" \
+    | cut -d "/" -f 3 \
+    | xargs -n 1 git push --delete origin
+else
+  git branch --merged origin/HEAD | grep -v '^*' | xargs git branch -d
+fi
+


### PR DESCRIPTION
See [this StackOverflow comment][1] for inspiration. I tested this on CycleDash and pileup.js.

[1]: http://stackoverflow.com/questions/8229737/how-to-delete-all-remote-git-branches-which-have-already-been-integrated/8236216#8236216