### PR TITLE
Fixes for git add-mirror-remote

### DIFF
--- a/remote/git-add-mirror-remote
+++ b/remote/git-add-mirror-remote
@@ -58,7 +58,7 @@ repo_init_commands = [
 passed_directory_existence_check = False
 try:
     if remote.is_remote:
-        check_call(['ssh', remote.host, '[ -d %s ]' % (remote.path if remote.path else '~') ])
+        check_call(['ssh', remote.user_host_str, '[ -d %s ]' % (remote.path if remote.path else '~') ])
     else:
         check_call(['[ -d %s ]' % (remote.path if remote.path else '~')])
 
@@ -81,7 +81,7 @@ if remote.is_remote:
 
     print('Running remote cmd: %s' % remote_cmd)
 
-    check_output(['ssh', remote.host, remote_cmd])
+    check_output(['ssh', remote.user_host_str, remote_cmd])
 
     print('Done!')
 else:

--- a/remote/git-copy-diffs
+++ b/remote/git-copy-diffs
@@ -24,7 +24,7 @@ os.chdir(root)
 
 print("Got remote %s at %s. Pushing.." % (
     remote.name,
-    remote.host_path_str,
+    remote.user_host_path_str,
 ))
 subprocess.check_output(['git', 'push', remote.name])
 print('Pushed!')
@@ -132,7 +132,7 @@ try:
     cmd = [
         cp,
         tar.name,
-        os.path.join(remote.host_path_str, tar_basename)
+        os.path.join(remote.user_host_path_str, tar_basename)
     ]
     print("%s'ing tar file: %s" % (cp, ' '.join(cmd)))
     subprocess.call(cmd)
@@ -140,7 +140,7 @@ try:
     cmd = [
         cp,
         local_script,
-        os.path.join(remote.host_path_str, remote_script_basename)
+        os.path.join(remote.user_host_path_str, remote_script_basename)
     ]
     print("%s'ing remote script: %s" % (cp, ' '.join(cmd)))
     subprocess.call(cmd)
@@ -155,7 +155,7 @@ try:
         ssh_cmd = [
             'ssh',
             #'-v',
-            remote.host,
+            remote.user_host_str,
             remote_cmd
         ]
 

--- a/remote/git-copy-diffs-rsync
+++ b/remote/git-copy-diffs-rsync
@@ -20,7 +20,7 @@ remote = get_mirror_remote()
 
 print("Got remote %s at %s. Copying .git directory to %s" % (
     remote.name,
-    remote.host_path_str,
+    remote.user_host_path_str,
     remote.path
 ))
 rsync_cmd = [ 'rsync', '-avzh', '--progress', '--delete', '.git', remote.user_host_path_str ]

--- a/util/remotes.py
+++ b/util/remotes.py
@@ -5,6 +5,9 @@ import re
 import subprocess
 import sys
 
+# Use the Python3 version of input(), even in Python2.
+if sys.version[0] == '2': input=raw_input
+
 name_regex = '(?P<name>[^\s]+)'
 opt_user_regex = '((?P<user>[^@]+)@)?'
 opt_host_regex = '(?:(?P<host>[^:]+):)?'
@@ -69,7 +72,7 @@ def remote_exists(remote_name):
 
 def prompt(p, default='y'):
     while True:
-        inp = raw_input(p)
+        inp = input(p)
         if (not inp and default.lower() == 'y') or inp.lower() == 'y' or inp.lower() == 'yes':
             return True
         if (not inp and default.lower() == 'n') or inp.lower() == 'n' or inp.lower() == 'no':

--- a/util/remotes.py
+++ b/util/remotes.py
@@ -69,7 +69,7 @@ def remote_exists(remote_name):
 
 def prompt(p, default='y'):
     while True:
-        inp = input(p)
+        inp = raw_input(p)
         if (not inp and default.lower() == 'y') or inp.lower() == 'y' or inp.lower() == 'yes':
             return True
         if (not inp and default.lower() == 'n') or inp.lower() == 'n' or inp.lower() == 'no':

--- a/util/remotes.py
+++ b/util/remotes.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 # Use the Python3 version of input(), even in Python2.
+# pylint: disable=undefined-variable
 if sys.version[0] == '2': input=raw_input
 
 name_regex = '(?P<name>[^\s]+)'


### PR DESCRIPTION
- Include login when running `ssh`
- Use `raw_input` instead of `input`, which tries to eval your response (fixes #78)