### PR TITLE
Only source git-completion in bash

### DIFF
--- a/.git-rc
+++ b/.git-rc
@@ -12,7 +12,10 @@ dir="$(cd "$dir" && echo "$PWD")"
 export GIT_HELPERS_HOME="$dir"
 
 [ -s "$dir/.gitcomplete" ] && source "$dir/.gitcomplete"
-[ -s "$dir/.git-completion.bash" ] && source "$dir/.git-completion.bash"
+
+if [ -n "$BASH_VERSION" ]; then
+  [ -s "$dir/.git-completion.bash" ] && source "$dir/.git-completion.bash"
+fi
 
 append_to_path() {
   for arg in "$@"; do


### PR DESCRIPTION
Fixes #75 

There is a [zsh version][1] of the completions file, but it's unclear to me what it does. I've got completions anyway, so dropping the include seems harmless.

[1]: https://github.com/git/git/blob/master/contrib/completion/git-completion.zsh