### PR TITLE
Allow ☃ unicode aûthors & commit méssagès.

### DIFF
--- a/test/branch_info_test.py
+++ b/test/branch_info_test.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+'''Tests for util/branch_info.py.
+
+Run via:
+
+    nosetests
+'''
+
+from util.branch_info import BranchInfo
+
+from nose.tools import *
+
+import sys
+
+
+def test_unicode_branch():
+    line = u'* unicøde        f557531 [origin/unicøde] Allow ☃ unicode messages.'
+    branch = BranchInfo(line)
+    eq_(branch.name, u'unicøde')
+    eq_(branch.hash, 'f557531')
+    eq_(branch.remote, u'origin/unicøde')
+    eq_(branch.description, u'Allow ☃ unicode messages.')

--- a/util/branch_info.py
+++ b/util/branch_info.py
@@ -12,7 +12,7 @@ import re
 
 def fixed(width, s, left_justified=False):
     spaces = (' ' * (width - clen(s)))
-    return unicode(s) + spaces if left_justified else spaces + unicode(s)
+    return s + spaces if left_justified else spaces + s
 
 
 class BranchInfo(object):

--- a/util/branch_info.py
+++ b/util/branch_info.py
@@ -12,7 +12,7 @@ import re
 
 def fixed(width, s, left_justified=False):
     spaces = (' ' * (width - clen(s)))
-    return str(s) + spaces if left_justified else spaces + str(s)
+    return unicode(s) + spaces if left_justified else spaces + unicode(s)
 
 
 class BranchInfo(object):
@@ -64,12 +64,12 @@ class BranchInfo(object):
     def __init__(self, line):
         self.line = line
 
-        match = re.match(self.regex(), line)
+        match = re.match(self.regex(), line, re.UNICODE)
         if (match):
             pass
         else:
             raise Exception(
-                "Invalid branch line:\n%s\nregex:\n%s" % (line, '\n'.join(self.regex_pieces)))
+                u'Invalid branch line:\n%s\nregex:\n%s' % (line, '\n'.join(self.regex_pieces)))
 
         self.dict = match.groupdict()
 

--- a/util/branch_infos.py
+++ b/util/branch_infos.py
@@ -31,7 +31,7 @@ class BranchInfos:
     def get_lines(self):
         out, err = subprocess.Popen(
             self.cmd(), stdout=subprocess.PIPE).communicate()
-        return out.decode().splitlines()
+        return out.decode('utf8').splitlines()
 
     def run_secondary_cmd(self):
         hashes = [bi.hash for bi in list(self.branches_by_name.values())]#map(lambda bi: bi.hash, self.branches_by_name.values())

--- a/util/color.py
+++ b/util/color.py
@@ -99,4 +99,4 @@ color_char_regex = '\x1b' + '\[(?:[0-9];)?[0-9]+m'
 
 
 def clen(s):
-    return len(re.sub(color_char_regex, '', unicode(s)))
+    return len(re.sub(color_char_regex, '', s))

--- a/util/color.py
+++ b/util/color.py
@@ -99,4 +99,4 @@ color_char_regex = '\x1b' + '\[(?:[0-9];)?[0-9]+m'
 
 
 def clen(s):
-    return len(re.sub(color_char_regex, '', str(s)))
+    return len(re.sub(color_char_regex, '', unicode(s)))

--- a/util/piece.py
+++ b/util/piece.py
@@ -12,7 +12,7 @@ import subprocess
 
 
 def fixed(width, s):
-    return (' ' * (width - clen(s))) + str(s)
+    return (' ' * (width - clen(s))) + unicode(s)
 
 
 class Piece(object):
@@ -26,7 +26,7 @@ class Piece(object):
 
 
     def render(self, segment):
-        return str(segment)
+        return unicode(segment)
 
 
     def __init__(self, name, git_format, fix_width=True, color='clear'):
@@ -139,7 +139,7 @@ class Pieces(object):
         if err:
             raise Exception(err.decode())
 
-        lines = out.decode().splitlines()
+        lines = out.decode('utf8').splitlines()
 
         self.results = []
 

--- a/util/piece.py
+++ b/util/piece.py
@@ -12,7 +12,7 @@ import subprocess
 
 
 def fixed(width, s):
-    return (' ' * (width - clen(s))) + unicode(s)
+    return (' ' * (width - clen(s))) + s
 
 
 class Piece(object):
@@ -26,7 +26,7 @@ class Piece(object):
 
 
     def render(self, segment):
-        return unicode(segment)
+        return segment
 
 
     def __init__(self, name, git_format, fix_width=True, color='clear'):

--- a/util/regexs.py
+++ b/util/regexs.py
@@ -1,7 +1,10 @@
 
 """Handy regexs for parsing git-command outputs."""
 
-normal_refname_regex = "[a-zA-Z0-9-_/\.+]+"
+# This is an approximation of valid branch names. The real rules are here:
+# https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html
+normal_refname_regex = r'[^ ~^:?*\[@\\]+'
+
 refname_or_tag_regex = "(?:(?:HEAD -> )?%s|tag: %s)" % (normal_refname_regex, normal_refname_regex)
 detached_refname_regex = "\((?:HEAD )?detached (?:from|at) %s\)" % normal_refname_regex
 no_branch_regex = "\(no branch\)"


### PR DESCRIPTION
Fixes #85 

I put non-ascii characters in various places. The one thing I noticed that still broke was running `git branches` when there's a branch name containing a unicode character.