### PR TITLE
append→insert to sys.path to fix local file interference

### DIFF
--- a/branch/git-branches
+++ b/branch/git-branches
@@ -9,7 +9,7 @@ if __name__ == '__main__':
     file_path = os.path.realpath(__file__)
     branches_dir = os.path.dirname(file_path)
     root_dir = os.path.dirname(branches_dir)
-    sys.path.append(root_dir)
+    sys.path.insert(0, root_dir)
 
 from util.branch_infos import BranchInfos
 

--- a/github/github
+++ b/github/github
@@ -8,7 +8,7 @@ if __name__ == '__main__':
     file_path = os.path.realpath(__file__)
     github_dir = os.path.dirname(file_path)
     root_dir = os.path.dirname(github_dir)
-    sys.path.append(root_dir)
+    sys.path.insert(0, root_dir)
 
 from util import github
 from util.root import git_root

--- a/log/git-lg
+++ b/log/git-lg
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     file_path = os.path.realpath(__file__)
     log_dir = os.path.dirname(file_path)
     root_dir = os.path.dirname(log_dir)
-    sys.path.append(root_dir)
+    sys.path.insert(0, root_dir)
 
 from util.piece import Pieces
 

--- a/remote/git-add-mirror-remote
+++ b/remote/git-add-mirror-remote
@@ -11,7 +11,7 @@ if __name__ == '__main__':
     file_path = os.path.realpath(__file__)
     branches_dir = os.path.dirname(file_path)
     root_dir = os.path.dirname(branches_dir)
-    sys.path.append(root_dir)
+    sys.path.insert(0, root_dir)
 
 from subprocess import CalledProcessError, check_call, check_output
 from util.remotes import get_remotes, maybe_remove_remote_if_exists, prompt

--- a/remote/git-copy-diffs
+++ b/remote/git-copy-diffs
@@ -7,7 +7,7 @@ if __name__ == '__main__':
     file_path = os.path.realpath(__file__)
     branches_dir = os.path.dirname(file_path)
     root_dir = os.path.dirname(branches_dir)
-    sys.path.append(root_dir)
+    sys.path.insert(0, root_dir)
 
 from dir import GitDirPath
 from util.remotes import get_mirror_remote

--- a/remote/git-copy-diffs-rsync
+++ b/remote/git-copy-diffs-rsync
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     file_path = os.path.realpath(__file__)
     branches_dir = os.path.dirname(file_path)
     root_dir = os.path.dirname(branches_dir)
-    sys.path.append(root_dir)
+    sys.path.insert(0, root_dir)
 
 from util.remotes import get_mirror_remote
 
@@ -148,4 +148,3 @@ run_cmd_on_local_and_remote(['git', 'lso'], rm_dest_untracked_files)
 check_cmd(['git', 'diff'])
 check_cmd(['git', 'diff', '--cached'])
 check_cmd(['git', 'lso'])
-

--- a/remote/git-load-github-prs
+++ b/remote/git-load-github-prs
@@ -9,7 +9,7 @@ if __name__ == '__main__':
     file_path = os.path.realpath(__file__)
     branches_dir = os.path.dirname(file_path)
     root_dir = os.path.dirname(branches_dir)
-    sys.path.append(root_dir)
+    sys.path.insert(0, root_dir)
 
 from subprocess import check_output, Popen, PIPE
 from util.remotes import get_remotes

--- a/remote/git-mirror-remote
+++ b/remote/git-mirror-remote
@@ -7,10 +7,8 @@ if __name__ == '__main__':
     file_path = os.path.realpath(__file__)
     branches_dir = os.path.dirname(file_path)
     root_dir = os.path.dirname(branches_dir)
-    sys.path.append(root_dir)
+    ssys.path.insert(0, root_dir)
 
 from util.remotes import get_mirror_remote
 
 print(get_mirror_remote().name)
-
-

--- a/tag/git-tags
+++ b/tag/git-tags
@@ -9,7 +9,7 @@ if __name__ == '__main__':
     file_path = os.path.realpath(__file__)
     branches_dir = os.path.dirname(file_path)
     root_dir = os.path.dirname(branches_dir)
-    sys.path.append(root_dir)
+    sys.path.insert(0, root_dir)
 
 from util.tags import print_recent_tags
 


### PR DESCRIPTION
Having a file that conflicts with one of the `git-helpers` modules was causing this:

![screen shot 2015-11-27 at 3 06 48 pm](https://cloud.githubusercontent.com/assets/7809/11447696/91d64a4a-9518-11e5-9377-d58e44065451.png)

These changes make sure that the `git-helpers` paths are prioritized over current working directory. 