### PR TITLE
Create temporary test directories in an OS-X-friendly way

### DIFF
--- a/config/.helpers-rc
+++ b/config/.helpers-rc
@@ -17,11 +17,11 @@ log() {
 }
 
 mkt() {
-  mktemp 2>/dev/null || mktemp -t 'mytmpdir'
+  mktemp 2>/dev/null || mktemp -t 'githelpers.tmp.fXX'
 }
 
 mktd() {
-  mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'
+  mktemp -d 2>/dev/null || mktemp -d -t 'githelpers.tmp.dXX'
 }
 
 # Simplify a path or paths by replacing them with the output of `pwd -P` from within them;

--- a/remote/git-unpack-and-apply-diffs
+++ b/remote/git-unpack-and-apply-diffs
@@ -5,6 +5,8 @@
 
 set -x
 
+source "$GIT_HELPERS_HOME"/config/.helpers-rc
+
 # TODO: arg-ify these
 tar="diffs.tar.gz"
 
@@ -21,8 +23,8 @@ echo "remote: git-unpack-and-apply-diffs!"
 
 set -e
 
-tmpdir="$(mktemp -d)"
-excludes_file="$(mktemp)"
+tmpdir="$(mktd)"
+excludes_file="$(mkt)"
 finish() {
   echo "Removing tmp dir containing $(find "$tmpdir" | wc -l) files"
   rm -rf "$tmpdir"
@@ -115,4 +117,3 @@ cp "$tmpdir/untracked.tar.gz" ./
 tar mxf untracked.tar.gz
 rm -f untracked.tar.gz
 echo ''
-

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,4 @@
+mock
 nose
 pylint
 python-dateutil

--- a/test/.helpers-rc
+++ b/test/.helpers-rc
@@ -8,8 +8,8 @@ test/clean-test-files
 
 mkdir -p tmp tmp1 tmp2
 
-tmp1="$(mktemp -d)"
-tmp2="$(mktemp -d)"
+tmp1="$(mktd)"
+tmp2="$(mktd)"
 
 check_link() {
   link="$1"

--- a/test/help/command-exists-test
+++ b/test/help/command-exists-test
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-#source "$GIT_HELPERS_HOME"/test/.helpers-rc
+source "$GIT_HELPERS_HOME"/test/.helpers-rc
 
 set -ex
 
-tmp="$(mktemp -d)"
+tmp="$(mktd)"
 
 finish() {
   rm -rf "$tmp"


### PR DESCRIPTION
Tests (run via `./run-tests`) were failing on my Mac OS X 10.10.5 due to this `mktemp` issue: http://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x

These changes allow working around the problem and fixes the tests on OS X systems.