### PR TITLE
add support for fetching a PR

### DIFF
--- a/fetch/.git-rc
+++ b/fetch/.git-rc
@@ -3,5 +3,6 @@
 alias gf="g f"
 alias gfo="g fo"
 alias gfu="g fu"
+alias gfpr="g fpr"
 
 

--- a/fetch/.gitconfig
+++ b/fetch/.gitconfig
@@ -2,3 +2,4 @@
   f = fetch --tags
   fo = fetch --tags origin
   fu = fetch --tags upstream
+  fpr = fetch-pr

--- a/fetch/git-fetch-pr
+++ b/fetch/git-fetch-pr
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Fetches a GitHub PR as a local branch
+#
+#   $ git fetch-pr <PR-number> <branch-name>
+#
+# e.g. 
+#   $ git fertch-pr 97 my-fancy-branch
+#
+# More: https://help.github.com/articles/checking-out-pull-requests-locally/
+
+if [ $# -eq 2 ]; then
+  git fetch origin pull/${1}/head:${2}
+else
+  echo "Usage: git fetch-pr <pr-number> <branch-name>"
+fi


### PR DESCRIPTION
Example use case:

```bash
$ gcln https://github.com/ryan-williams/git-helpers.git
Cloning into 'git-helpers'...
remote: Counting objects: 2635, done.
remote: Total 2635 (delta 0), reused 0 (delta 0), pack-reused 2635
Receiving objects: 100% (2635/2635), 371.24 KiB | 0 bytes/s, done.
Resolving deltas: 100% (1351/1351), done.
Checking connectivity... done. 

$ cd git-helpers
$ gfpr 97 my-pr
From https://github.com/ryan-williams/git-helpers
 * [new ref]         refs/pull/97/head -> my-pr
```

Good for checking PRs out for local inspection.