### PR TITLE
Quiet export

### DIFF
--- a/.git-rc
+++ b/.git-rc
@@ -21,7 +21,7 @@ define-function() {
   name="$1"
   shift
   eval "$name() { $@ \"\$@\"; }"
-  export -f "$name"
+  export -f "$name" > /dev/null
 }
 alias defn=define-function
 


### PR DESCRIPTION
Just setting up a new machine today and noticed that, without this, I see some noise whenever I source `git-helpers/.git-rc` using zsh.